### PR TITLE
Additional template variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-short_ver = $(shell git describe --abbrev=0 2>/dev/null || echo 0.0.1)
+short_ver = $(shell git describe --abbrev=0 2>/dev/null || echo 0.0.2)
 long_ver = $(shell git describe --long 2>/dev/null || echo $(short_ver)-0-unknown-g`git describe --always`)
 
 SOURCES := \

--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ The parameter supports templating using `{{ var }}` for variables that will be s
 
 Currently supported variables are:
 - `{{ utc_date }}` - the current date in UTC time zone.
+- `{{ utc_year }}` - the current year in UTC time zone.
+- `{{ utc_month }}` - the current month in UTC time zone.
+- `{{ utc_day }}` - the current day of the month in UTC time zone.
 - `{{ local_date }}` - the current date in the local time zone.
+- `{{ local_year }}` - the current year in the local time zone.
+- `{{ local_month }}` - the current month in the local time zone.
+- `{{ local_day }}` - the current day of the month in the local time zone.
 
 Both dates are formatted in ISO 8601 format, e.g.: `2019-03-26`.
 

--- a/aiven-kafka-connect-s3.spec
+++ b/aiven-kafka-connect-s3.spec
@@ -30,3 +30,6 @@ install target/aiven-kafka-connect-s3-%{version}.jar %{buildroot}/opt/aiven-kafk
 %changelog
 * Wed Oct  5 2016 Heikki Nousiainen <htn@aiven.io>
 - First build
+
+* Thurs Dec 5 2019 Alan Kehoe <alankehoe111@gmail.com>
+- Add the following template variables [utc_year, utc_month, utc_day, local_year, local_month, local_day]

--- a/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkTask.java
@@ -60,18 +60,18 @@ public class AivenKafkaConnectS3SinkTask extends SinkTask {
 
     private final TemplatingEngine templatingEngine = new TemplatingEngine();
     {
-        ZonedDateTime dateTime = ZonedDateTime.now(ZoneId.of("UTC"));
+        ZonedDateTime utcDateTime = ZonedDateTime.now(ZoneId.of("UTC"));
         templatingEngine.bindVariable("utc_date",
-                () -> dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE)
+                () -> utcDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE)
         );
         templatingEngine.bindVariable("utc_year",
-            () -> String.valueOf(dateTime.getYear())
+            () -> String.valueOf(utcDateTime.getYear())
         );
         templatingEngine.bindVariable("utc_month",
-            () ->  String.valueOf(dateTime.getMonth())
+            () ->  String.valueOf(utcDateTime.getMonth())
         );
         templatingEngine.bindVariable("utc_day",
-            () -> String.valueOf(dateTime.getDayOfMonth())
+            () -> String.valueOf(utcDateTime.getDayOfMonth())
         );
     
         LocalDateTime localDateTime = LocalDateTime.now();

--- a/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkTask.java
@@ -60,11 +60,32 @@ public class AivenKafkaConnectS3SinkTask extends SinkTask {
 
     private final TemplatingEngine templatingEngine = new TemplatingEngine();
     {
+        ZonedDateTime dateTime = ZonedDateTime.now(ZoneId.of("UTC"));
         templatingEngine.bindVariable("utc_date",
-                () -> ZonedDateTime.now(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_LOCAL_DATE)
+                () -> dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE)
         );
+        templatingEngine.bindVariable("utc_year",
+            () -> String.valueOf(dateTime.getYear())
+        );
+        templatingEngine.bindVariable("utc_month",
+            () ->  String.valueOf(dateTime.getMonth())
+        );
+        templatingEngine.bindVariable("utc_day",
+            () -> String.valueOf(dateTime.getDayOfMonth())
+        );
+    
+        LocalDateTime localDateTime = LocalDateTime.now();
         templatingEngine.bindVariable("local_date",
-                () -> LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+                () -> localDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE)
+        );
+        templatingEngine.bindVariable("local_year",
+            () -> String.valueOf(localDateTime.getYear())
+        );
+        templatingEngine.bindVariable("local_month",
+            () ->  String.valueOf(localDateTime.getMonth())
+        );
+        templatingEngine.bindVariable("local_day",
+            () -> String.valueOf(localDateTime.getDayOfMonth())
         );
     }
 


### PR DESCRIPTION
Add the following template variables [utc_year, utc_month, utc_day, local_year, local_month, local_day]

The specific use we have it to output to an s3 bucket with the following pattern:
`<prefix>/2019/12/05/<topic>-<partition>-<startoffset>[.gz]`