### PR TITLE
Change Commons to republished version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ ext {
     kafkaVersion = "1.1.0"
     amazonS3Version = "1.11.718"
     slf4jVersion = "1.7.25"
-    aivenConnectCommonsVersion = "0.0.1"
+    aivenConnectCommonsVersion = "0.1.0"
     junitVersion = "5.6.2"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ repositories {
     mavenLocal()
     jcenter()
     maven {
-        url "https://aiven.bintray.com/maven"
+        url "http://dl.bintray.com/aiven/maven"
     }
 }
 


### PR DESCRIPTION
The Commons version was re-published under the version 0.1.0.

Also the Bintray repo URL was incorrect, changed.