### PR TITLE
Don't use env variable for version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ plugins {
 }
 
 group = "io.aiven"
-version = System.getenv("RELEASE_VERSION") ?: "0-SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
We have the version defined in `gradle.properties`.