### PR TITLE
[Suggestion] Add key value generator for test

### DIFF
--- a/src/integration-test/java/io/aiven/kafka/connect/IntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/IntegrationTest.java
@@ -38,6 +38,9 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import io.aiven.kafka.connect.common.config.CompressionType;
 import io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector;
 import io.aiven.kafka.connect.s3.testutils.BucketAccessor;
+import io.aiven.kafka.connect.s3.testutils.IndexesToString;
+import io.aiven.kafka.connect.s3.testutils.KeyValueGenerator;
+import io.aiven.kafka.connect.s3.testutils.KeyValueMessage;
 
 import cloud.localstack.Localstack;
 import cloud.localstack.awssdkv1.TestUtils;
@@ -126,16 +129,13 @@ final class IntegrationTest implements KafkaIntegrationBase {
         connectRunner.createConnector(connectorConfig);
 
         final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
-        int cnt = 0;
-        for (int i = 0; i < 10; i++) {
-            for (int partition = 0; partition < 4; partition++) {
-                final String key = "key-" + cnt;
-                final String value = "value-" + cnt;
-                cnt += 1;
+        final IndexesToString keyGen = (partition, epoch, currIdx) -> "key-" + currIdx;
+        final IndexesToString valueGen = (partition, epoch, currIdx) -> "value-" + currIdx;
 
-                sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, partition, key, value));
-            }
+        for (final KeyValueMessage msg : new KeyValueGenerator(4, 10, keyGen, valueGen)) {
+            sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, msg.partition, msg.key, msg.value));
         }
+
         producer.flush();
         for (final Future<RecordMetadata> sendFuture : sendFutures) {
             sendFuture.get();
@@ -162,18 +162,11 @@ final class IntegrationTest implements KafkaIntegrationBase {
             );
         }
 
-        cnt = 0;
-        for (int i = 0; i < 10; i++) {
-            for (int partition = 0; partition < 4; partition++) {
-                final String key = "key-" + cnt;
-                final String value = "value-" + cnt;
-                cnt += 1;
-
-                final String blobName = getBlobName(partition, 0, compression);
-                final String actualLine = blobContents.get(blobName).get(i);
-                final String expectedLine = key + "," + value;
-                assertEquals(expectedLine, actualLine);
-            }
+        for (final KeyValueMessage msg : new KeyValueGenerator(4, 10, keyGen, valueGen)) {
+            final String blobName = getBlobName(msg.partition, 0, compression);
+            final String actualLine = blobContents.get(blobName).get(msg.epoch);
+            final String expectedLine = msg.key + "," + msg.value;
+            assertEquals(expectedLine, actualLine);
         }
     }
 

--- a/src/test/java/io/aiven/kafka/connect/s3/testutils/IndexesToString.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/testutils/IndexesToString.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3.testutils;
+
+@FunctionalInterface
+public interface IndexesToString {
+    String generate(final int partition,
+                    final int epoch,
+                    final int currIdx);
+}

--- a/src/test/java/io/aiven/kafka/connect/s3/testutils/KeyValueGenerator.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/testutils/KeyValueGenerator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3.testutils;
+
+import java.util.Iterator;
+
+public class KeyValueGenerator implements Iterable<KeyValueMessage> {
+
+    public final int numPartitions;
+    public final int numEpochs;
+    public final IndexesToString keyGenerator;
+    public final IndexesToString valueGenerator;
+
+    public KeyValueGenerator(final int numPartitions,
+                             final int numEpochs,
+                             final IndexesToString keyGenerator,
+                             final IndexesToString valueGenerator) {
+        this.numPartitions = numPartitions;
+        this.numEpochs = numEpochs;
+        this.keyGenerator = keyGenerator;
+        this.valueGenerator = valueGenerator;
+    }
+
+    @Override
+    public Iterator<KeyValueMessage> iterator() {
+        return new Iterator<>() {
+            int partition = 0;
+            int epoch = 0;
+            int currIdx = 0;
+
+            @Override
+            public boolean hasNext() {
+                return epoch < numEpochs;
+            }
+
+            @Override
+            public KeyValueMessage next() {
+                final KeyValueMessage msg =
+                    new KeyValueMessage(keyGenerator.generate(partition, epoch, currIdx),
+                                         valueGenerator.generate(partition, epoch, currIdx),
+                                         partition,
+                                         currIdx,
+                                         epoch
+                    );
+                currIdx += 1;
+                partition += 1;
+                if (partition >= numPartitions) {
+                    epoch += 1;
+                    partition = 0;
+                }
+                return msg;
+            }
+        };
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/s3/testutils/KeyValueMessage.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/testutils/KeyValueMessage.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3.testutils;
+
+public class KeyValueMessage {
+    public final String key;
+    public final String value;
+    public final int partition;
+    public final int idx;
+    public final int epoch;
+
+    public KeyValueMessage(final String key,
+                           final String value,
+                           final int partition,
+                           final int idx,
+                           final int epoch) {
+        this.key = key;
+        this.value = value;
+        this.partition = partition;
+        this.idx = idx;
+        this.epoch = epoch;
+    }
+}


### PR DESCRIPTION
__WHY__:
Idea is that key-value generator reduces test size and makes generated messages exactly equal to expected messages.

I noticed that values and keys are generated the same way for all GCS integrational tests. 
This could probably will happened with S3 tests too.

__WHAT__:
Add an Integator that generate keys and values according to a existing testing patters and generate equal number of messages for each partition.