### PR TITLE
Refactor S3 config

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -21,6 +21,9 @@
 <suppressions>
 
     <!-- switch statements on types exceed maximum complexity -->
+    <suppress checks="(CyclomaticComplexity)"
+              files="(S3SinkConfig).java"/>
+
     <suppress checks="(ClassFanOutComplexity)"
               files="(S3SinkConfig|S3SinkTaskTest|IntegrationTest).java"/>
 


### PR DESCRIPTION
__WHY__:
1) Config refactoring to support new `output.format.type` (for JSON converter) and 
2) Reduces `Add record grouper`  PR:https://github.com/aiven/aiven-kafka-connect-s3/pull/45

__WHAT__:
- Use a Common Config
- Remove Common keys 
- Use common `addOutputFieldsFormatConfigGroup` instead of `addFormatConfigGroup`