### PR TITLE
Add Jsonl output type

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,24 @@ The connector creates one file per Kafka Connect `offset.flush.interval.ms` sett
 Output files are text files that contain one record per line (i.e.,
 they're separated by `\n`).
 
+There are two types of data format available: 
+ - **[Default]** Flat structure, where field values are separated by comma (`csv`)
+
+    Configuration: ```format.output.type=csv```. 
+    Also, this is the default if the property is not present in the configuration.
+
+ - Complex structure, where file is in format of [JSON lines](https://jsonlines.org/). 
+    It contains one record per line and each line is a valid JSON object(`jsonl`)
+
+    Configuration: ```format.output.type=jsonl```. 
+
 The connector can output the following fields from records into the
 output: the key, the value, the timestamp, and the offset. (The set and the order of
+output: the key, the value, the timestamp, and the offset. (The set of
 these output fields is configurable.) The field values are separated by comma.
+
+
+#### CSV Format example
 
 The key and the value—if they're output—are stored as binaries encoded
 in [Base64](https://en.wikipedia.org/wiki/Base64).
@@ -56,6 +71,38 @@ output instead:
 
 A comma separated list of fields to include in output. Supported values are: `key`, `offset`, `timestamp`, `headers`, and `value`. Defaults to `value`.
 
+**NB!**
+
+ - The `key.converter` property must be set to `org.apache.kafka.connect.converters.ByteArrayConverter`
+or `org.apache.kafka.connect.storage.StringConverter` for this data format.
+
+ - The `value.converter` property must be set to `org.apache.kafka.connect.converters.ByteArrayConverter` for this data format.
+ 
+#### JSONL Format example
+
+For example, if we output `key,value,offset,timestamp`, a record line might look like:
+
+```
+{ "key": "k1", "value": "v0", "offset": 1232155, "timestamp":"2020-01-01T00:00:01Z" }
+```
+
+OR
+
+```
+{ "key": "user1", "value": {"name": "John", "address": {"city": "London"}}, "offset": 1232155, "timestamp":"2020-01-01T00:00:01Z" }
+```
+
+It is recommended to use
+- `org.apache.kafka.connect.storage.StringConverter` or 
+- `org.apache.kafka.connect.json.JsonConverter`
+
+as `key.converter` or `value.converter` to make an output file human-readable.
+
+**NB!**
+
+ - The value of the `format.output.fields.value.encoding` property is ignored for this data format.
+ - Value/Key schema will not be presented in output file, even if `value.converter.schemas.enable` property is `true`.
+ But, it is still important to set this property correctly, so that connector could read records correctly. 
 ## Usage
 
 ### Connector Configuration
@@ -103,12 +150,14 @@ curl -X POST \
                 "aws_s3_prefix": "example-s3-sink/",
                 "aws_s3_region": "us-east-1",
                 "connector.class": "io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector",
-                "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+                "format.output.type": "jsonl"
+                "key.converter": "org.apache.kafka.connect.storage.StringConverter",
                 "output_compression": "gzip",
                 "output_fields": "value,key,timestamp",
                 "tasks.max": 1,
                 "topics": "source_topic,another_topic",
-                "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter"
+                "value.converter": "org.apache.kafka.connect.json.JsonConverter"
+                "value.converter.schemas.enable": false
             }
         }
     EOF
@@ -154,13 +203,19 @@ Here is an example connector configuration with descriptions:
 connector.class=io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector
 
 # The key converter for this connector
-# (must be set to org.apache.kafka.connect.converters.ByteArrayConverter
-# or org.apache.kafka.connect.storage.StringConverter)
-key.converter=org.apache.kafka.connect.converters.ByteArrayConverter
+key.converter=org.apache.kafka.connect.storage.StringConverter
 
 # The value converter for this connector
-# (must be set to ByteArrayConverter)
-value.converter=org.apache.kafka.connect.converters.ByteArrayConverter
+value.converter=org.apache.kafka.connect.json.JsonConverter
+
+# Identify, if value contains a schema.
+# Required value converter is `org.apache.kafka.connect.json.JsonConverter`.
+value.converter.schemas.enable=false
+
+# The type of data format used to write data to the GCS output files.
+# The supported values are: `csv`, `jsonl`.
+# Optional, the default is `csv`.
+format.output.type=jsonl
 
 # A comma-separated list of topics to use as input for this connector
 # Also a regular expression version `topics.regex` is supported.

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ ext {
     kafkaVersion = "1.1.0"
     amazonS3Version = "1.11.718"
     slf4jVersion = "1.7.25"
-    aivenConnectCommonsVersion = "0.1.0"
+    aivenConnectCommonsVersion = "0.2.0"
     junitVersion = "5.6.2"
     testcontainersVersion = "1.12.0"
     localstackVersion = "0.2.5"
@@ -122,6 +122,7 @@ dependencies {
 
     testImplementation "org.apache.kafka:connect-api:$kafkaVersion"
     testImplementation "org.apache.kafka:connect-runtime:$kafkaVersion"
+    testImplementation "org.apache.kafka:connect-json:$kafkaVersion"
     testImplementation "org.slf4j:slf4j-simple:$slf4jVersion"
     testImplementation "io.aiven:aiven-kafka-connect-commons:$aivenConnectCommonsVersion"
     testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"

--- a/src/main/java/io/aiven/kafka/connect/s3/S3SinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/S3SinkConfig.java
@@ -97,6 +97,7 @@ public class S3SinkConfig extends AivenCommonConfig {
     //      Importance was set to medium,
     //      as soon we will migrate to new values it must be set to HIGH
     //      same for default value
+
     private static final String GROUP_AWS = "AWS";
     private static final String GROUP_FILE = "File";
     private static final String GROUP_FORMAT = "Format";

--- a/src/test/java/io/aiven/kafka/connect/common/config/S3SinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/config/S3SinkConfigTest.java
@@ -98,7 +98,7 @@ class S3SinkConfigTest {
             ),
             conf.getOutputFields()
         );
-
+        assertEquals(FormatType.forName("csv"), conf.getFormatType());
     }
 
     @Test
@@ -672,6 +672,38 @@ class S3SinkConfigTest {
             ),
             renderedPrefix
         );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"jsonl", "csv"})
+    void supportedFormatTypeConfig(final String formatType) {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(S3SinkConfig.AWS_ACCESS_KEY_ID_CONFIG, "any_access_key_id");
+        properties.put(S3SinkConfig.AWS_SECRET_ACCESS_KEY_CONFIG, "any_secret_key");
+        properties.put(S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG, "any_bucket");
+        properties.put(S3SinkConfig.AWS_S3_PREFIX_CONFIG, "any_prefix");
+        properties.put(S3SinkConfig.FORMAT_OUTPUT_TYPE_CONFIG, formatType);
+
+
+        final S3SinkConfig c = new S3SinkConfig(properties);
+        final FormatType expectedFormatType = FormatType.forName(formatType);
+
+        assertEquals(expectedFormatType, c.getFormatType());
+    }
+
+    @Test
+    void wrongFormatTypeConfig() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(S3SinkConfig.FORMAT_OUTPUT_TYPE_CONFIG, "unknown");
+
+        final Throwable t = assertThrows(
+            ConfigException.class,
+            () -> new S3SinkConfig(properties)
+        );
+        assertEquals(
+            "Invalid value unknown for configuration format.output.type: "
+                + "supported values are: 'csv', 'jsonl'", t.getMessage());
+
     }
 
 }

--- a/src/test/java/io/aiven/kafka/connect/s3/testutils/BucketAccessor.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/testutils/BucketAccessor.java
@@ -74,11 +74,6 @@ public class BucketAccessor {
 
     public final List<String> readLines(final String blobName, final String compression) throws IOException {
         Objects.requireNonNull(blobName, "blobName cannot be null");
-        return readLines0(blobName, compression);
-    }
-
-    private List<String> readLines0(final String blobName, final String compression) throws IOException {
-        Objects.requireNonNull(blobName, "blobName cannot be null");
         final byte[] blobBytes = s3.getObject(bucketName, blobName).getObjectContent().readAllBytes();
 
         try (final ByteArrayInputStream bais = new ByteArrayInputStream(blobBytes)) {


### PR DESCRIPTION
__WHY__:
S3SinkTask should be able to store events in a JSONL format.
Twin-brother of [this GCS PR](https://github.com/aiven/aiven-kafka-connect-gcs/pull/64)

__WHAT__:

- Added new configuration 'format.output.type'
- Added integration Test for 'jsonl' format(happy case)
- GCSSinkTask Unittest
- README

Have to Merge previous PRs first.