### PR TITLE
Add Classic JSON support

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ There are two types of data format available:
     It contains one record per line and each line is a valid JSON object(`jsonl`)
 
     Configuration: ```format.output.type=jsonl```. 
+    
+ - Complex structure, where file is a valid JSON array of record objects. 
+  
+     Configuration: ```format.output.type=json```. 
 
 The connector can output the following fields from records into the
 output: the key, the value, the timestamp, and the offset. (The set and the order of
@@ -259,6 +263,39 @@ as `key.converter` and/or `value.converter` to make output files human-readable.
  - The value of the `format.output.fields.value.encoding` property is ignored for this data format.
  - Value/Key schema will not be presented in output file, even if `value.converter.schemas.enable` property is `true`.
  But, it is still important to set this property correctly, so that connector could read records correctly. 
+ 
+#### JSON Format example
+
+For example, if we output `key,value,offset,timestamp`, an output file might look like:
+
+```
+[
+{ "key": "k1", "value": "v0", "offset": 1232155, "timestamp":"2020-01-01T00:00:01Z" },
+{ "key": "k2", "value": "v1", "offset": 1232156, "timestamp":"2020-01-01T00:00:05Z" }
+]
+```
+
+OR
+
+```
+[
+{ "key": "user1", "value": {"name": "John", "address": {"city": "London"}}, "offset": 1232155, "timestamp":"2020-01-01T00:00:01Z" }
+]
+```
+
+It is recommended to use
+- `org.apache.kafka.connect.storage.StringConverter`, 
+- `org.apache.kafka.connect.json.JsonConverter`, or
+- `io.confluent.connect.avro.AvroConverter`.
+ 
+as `key.converter` and/or `value.converter` to make output files human-readable.
+
+**NB!**
+
+ - The value of the `format.output.fields.value.encoding` property is ignored for this data format.
+ - Value/Key schema will not be presented in output file, even if `value.converter.schemas.enable` property is `true`.
+ But, it is still important to set this property correctly, so that connector could read records correctly. 
+
 ## Usage
 
 ### Connector Configuration

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ ext {
     confluentPlatformVersion = "4.1.4"
     amazonS3Version = "1.11.718"
     slf4jVersion = "1.7.25"
-    aivenConnectCommonsVersion = "0.2.0"
+    aivenConnectCommonsVersion = "0.3.1"
     junitVersion = "5.6.2"
     testcontainersVersion = "1.12.0"
     localstackVersion = "0.2.5"
@@ -121,8 +121,6 @@ dependencies {
     implementation "org.xerial.snappy:snappy-java:1.1.7.5"
     implementation "com.github.luben:zstd-jni:1.4.5-4"
 
-    runtimeOnly "org.slf4j:slf4j-log4j12:$slf4jVersion"
-
     compileOnly "org.apache.kafka:connect-api:$kafkaVersion"
     compileOnly "org.apache.kafka:connect-runtime:$kafkaVersion"
     compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
@@ -137,6 +135,7 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest:2.1"
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+    testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.3'
 
     integrationTestImplementation "org.apache.kafka:connect-api:$kafkaVersion"
     integrationTestImplementation "org.apache.kafka:connect-runtime:$kafkaVersion"

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -25,9 +25,9 @@
               files="(S3SinkConfig).java"/>
 
     <suppress checks="(ClassFanOutComplexity)"
-              files="(S3SinkConfig|S3SinkTaskTest|IntegrationTest).java"/>
+              files="(S3SinkTask|S3SinkConfig|S3SinkTaskTest|IntegrationTest).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(S3SinkConfig|S3SinkTaskTest).java"/>
+              files="(S3SinkTask|S3SinkConfig|S3SinkTaskTest).java"/>
 
 </suppressions>

--- a/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
@@ -631,7 +631,7 @@ class S3SinkConfigTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"jsonl", "csv"})
+    @ValueSource(strings = {"jsonl", "json", "csv"})
     void supportedFormatTypeConfig(final String formatType) {
         final Map<String, String> properties = new HashMap<>();
         properties.put(S3SinkConfig.AWS_ACCESS_KEY_ID_CONFIG, "any_access_key_id");
@@ -658,7 +658,7 @@ class S3SinkConfigTest {
         );
         assertEquals(
             "Invalid value unknown for configuration format.output.type: "
-                + "supported values are: 'csv', 'jsonl'", t.getMessage());
+                + "supported values are: 'csv', 'json', 'jsonl'", t.getMessage());
 
     }
 


### PR DESCRIPTION
Similar to https://github.com/aiven/aiven-kafka-connect-gcs/pull/68, this PR adds the support for "classic" JSON output.