### PR TITLE
Replace YYYY with yyyy in template formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ It supports placeholders with variable names:
 - `topic` - the Kafka topic;
 - `partition` - the Kafka partition;
 - `start_offset:padding=true|false` - the Kafka offset of the first record in the file, if `padding` sets to `true` will set leading zeroes for offset, default is `false`;
-- `timestamp:unit=YYYY|MM|dd|HH` - the timestamp of when the Kafka record has been processed by the connector.
+- `timestamp:unit=yyyy|MM|dd|HH` - the timestamp of when the Kafka record has been processed by the connector.
    - `unit` parameter values:
-     - `YYYY` - year, e.g. `2020`
+     - `yyyy` - year, e.g. `2020` (please note that `YYYY` is deprecated and is interpreted as `yyyy`)
      - `MM` - month, e.g. `03`
      - `dd` - day, e.g. `01`
      - `HH` - hour, e.g. `24` 
@@ -50,7 +50,7 @@ For example: `{{topic}}-{{partition}}-{{start_offset:padding=true}}.gz`
 will produce file names like `mytopic-1-00000000000000000001.gz`.
 
 To add formatted timestamps, use `timestamp` variable.<br/>
-For example: `{{topic}}-{{partition}}-{{start_offset}}-{{timestamp:unit=YYYY}}{{timestamp:unit=MM}}{{timestamp:unit=dd}}.gz` 
+For example: `{{topic}}-{{partition}}-{{start_offset}}-{{timestamp:unit=yyyy}}{{timestamp:unit=MM}}{{timestamp:unit=dd}}.gz` 
 will produce file names like `mytopic-2-1-20200301.gz`.
 
 To configure the time zone for the `timestamp` variable,

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ ext {
     confluentPlatformVersion = "4.1.4"
     amazonS3Version = "1.11.718"
     slf4jVersion = "1.7.25"
-    aivenConnectCommonsVersion = "0.3.1"
+    aivenConnectCommonsVersion = "0.4.0"
     junitVersion = "5.6.2"
     testcontainersVersion = "1.12.0"
     localstackVersion = "0.2.5"

--- a/src/integration-test/java/io/aiven/kafka/connect/IntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/IntegrationTest.java
@@ -193,7 +193,7 @@ final class IntegrationTest implements KafkaIntegrationBase {
         connectorConfig.put(
             "file.name.template",
             s3Prefix + "{{topic}}-{{partition}}-{{start_offset}}-"
-                + "{{timestamp:unit=YYYY}}-{{timestamp:unit=MM}}-{{timestamp:unit=dd}}"
+                + "{{timestamp:unit=yyyy}}-{{timestamp:unit=MM}}-{{timestamp:unit=dd}}"
         );
         connectRunner.createConnector(connectorConfig);
 

--- a/src/main/java/io/aiven/kafka/connect/s3/OldFullKeyFormatters.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/OldFullKeyFormatters.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.config.TimestampSource;
+import io.aiven.kafka.connect.common.templating.VariableTemplatePart;
+
+public final class OldFullKeyFormatters {
+    public static final BiFunction<SinkRecord, VariableTemplatePart.Parameter, String> KAFKA_OFFSET =
+        (sinkRecord, usePaddingParameter) ->
+            usePaddingParameter.asBoolean()
+                ? String.format("%020d", sinkRecord.kafkaOffset())
+                : Long.toString(sinkRecord.kafkaOffset());
+
+    public static final BiFunction<TimestampSource, VariableTemplatePart.Parameter, String> TIMESTAMP =
+        new BiFunction<>() {
+
+            private final Map<String, DateTimeFormatter> formatterMap =
+                Map.of(
+                    "YYYY", DateTimeFormatter.ofPattern("YYYY"),
+                    "MM", DateTimeFormatter.ofPattern("MM"),
+                    "dd", DateTimeFormatter.ofPattern("dd"),
+                    "HH", DateTimeFormatter.ofPattern("HH")
+                );
+
+            @Override
+            public String apply(final TimestampSource tsSource, final VariableTemplatePart.Parameter parameter) {
+                return tsSource.time().format(formatterMap.get(parameter.value()));
+            }
+        };
+}

--- a/src/main/java/io/aiven/kafka/connect/s3/OldFullKeyFormatters.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/OldFullKeyFormatters.java
@@ -37,7 +37,7 @@ public final class OldFullKeyFormatters {
 
             private final Map<String, DateTimeFormatter> formatterMap =
                 Map.of(
-                    "YYYY", DateTimeFormatter.ofPattern("YYYY"),
+                    "yyyy", DateTimeFormatter.ofPattern("yyyy"),
                     "MM", DateTimeFormatter.ofPattern("MM"),
                     "dd", DateTimeFormatter.ofPattern("dd"),
                     "HH", DateTimeFormatter.ofPattern("HH")

--- a/src/main/java/io/aiven/kafka/connect/s3/S3SinkConfigDef.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/S3SinkConfigDef.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
+
+public class S3SinkConfigDef extends ConfigDef {
+    @Override
+    public List<ConfigValue> validate(final Map<String, String> props) {
+        return super.validate(S3SinkConfig.preprocessProperties(props));
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
@@ -34,8 +34,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 
-import io.aiven.kafka.connect.common.config.FormatterUtils;
-import io.aiven.kafka.connect.common.config.Variables;
+import io.aiven.kafka.connect.common.config.FilenameTemplateVariable;
 import io.aiven.kafka.connect.common.grouper.RecordGrouper;
 import io.aiven.kafka.connect.common.grouper.RecordGrouperFactory;
 import io.aiven.kafka.connect.common.output.OutputWriter;
@@ -193,18 +192,18 @@ public class S3SinkTask extends SinkTask {
             config.getPrefixTemplate()
                 .instance()
                 .bindVariable(
-                    Variables.TIMESTAMP.name,
-                    parameter -> FormatterUtils.formatTimestamp.apply(config.getTimestampSource(), parameter)
+                    FilenameTemplateVariable.TIMESTAMP.name,
+                    parameter -> OldFullKeyFormatters.TIMESTAMP.apply(config.getTimestampSource(), parameter)
                 )
                 .bindVariable(
-                    Variables.PARTITION.name,
+                    FilenameTemplateVariable.PARTITION.name,
                     () -> record.kafkaPartition().toString()
                 )
                 .bindVariable(
-                    Variables.START_OFFSET.name,
-                    parameter -> FormatterUtils.formatKafkaOffset.apply(record, parameter)
+                    FilenameTemplateVariable.START_OFFSET.name,
+                    parameter -> OldFullKeyFormatters.KAFKA_OFFSET.apply(record, parameter)
                 )
-                .bindVariable(Variables.TOPIC.name, record::topic)
+                .bindVariable(FilenameTemplateVariable.TOPIC.name, record::topic)
                 .bindVariable(
                     "utc_date",
                     () -> ZonedDateTime.now(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_LOCAL_DATE)
@@ -219,7 +218,7 @@ public class S3SinkTask extends SinkTask {
                 "%s-%s-%s",
                 record.topic(),
                 record.kafkaPartition(),
-                FormatterUtils.formatKafkaOffset.apply(
+                OldFullKeyFormatters.KAFKA_OFFSET.apply(
                     record, VariableTemplatePart.Parameter.of("padding", "true")
                 )
             );

--- a/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
@@ -28,10 +28,10 @@ import org.apache.kafka.common.config.ConfigException;
 
 import io.aiven.kafka.connect.common.config.CompressionType;
 import io.aiven.kafka.connect.common.config.FormatType;
-import io.aiven.kafka.connect.common.config.FormatterUtils;
 import io.aiven.kafka.connect.common.config.OutputField;
 import io.aiven.kafka.connect.common.config.OutputFieldEncodingType;
 import io.aiven.kafka.connect.common.config.OutputFieldType;
+import io.aiven.kafka.connect.s3.OldFullKeyFormatters;
 import io.aiven.kafka.connect.s3.S3SinkConfig;
 
 import com.amazonaws.regions.Regions;
@@ -616,7 +616,7 @@ class S3SinkConfigTest {
             config.getPrefixTemplate()
                 .instance()
                 .bindVariable("timestamp", parameter ->
-                    FormatterUtils.formatTimestamp.apply(config.getTimestampSource(), parameter))
+                    OldFullKeyFormatters.TIMESTAMP.apply(config.getTimestampSource(), parameter))
                 .render();
 
         assertEquals(


### PR DESCRIPTION
Originally we introduced `{{timestamp:unit=YYYY}}` to render the year of the timestamp in the template. We passed `YYYY` directly into Java's timestamp formatting. However, `YYYY` is bit different from `yyyy`, which users actually want.

This PR fixes this. Luckily, the connector has never been released with `YYYY`, so we're free from the burden of backward compatibility here.

See individual commits for details + the sibling PR https://github.com/aiven/aiven-kafka-connect-gcs/pull/71