### PR TITLE
support S3 cross-account AssumeRole

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,25 @@ The connector needs the following permissions to the specified bucket:
 
 In case of ``Access Denied`` error see https://aws.amazon.com/premiumsupport/knowledge-center/s3-troubleshoot-403/
 
+### Credentials
+
+To make the connector work, a user has to specify AWS credentials that allow writing to S3.
+There are two ways to specify AWS credentials in this connector:
+
+1) Long term credentials.
+
+   It requires both `aws.access.key.id` and `aws.secret.access.key` to be specified.
+2) Short term credentials.
+
+   The connector will request a temporary token from the AWS STS service and assume a role from another AWS account.
+   It requires `aws.sts.role.arn`, `aws.sts.role.session.name` to be specified.
+
+It is important not to use both.
+Using option 2, it is recommended to specify the S3 bucket region in `aws.s3.region` and the
+corresponding AWS STS endpoint in `aws.sts.config.endpoint`. It's better to specify both or none.
+It is also important to specify `aws.sts.role.external.id` for the security reason.
+(see some details [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)).
+
 ### File name format
 
 The connector uses the following format for output files (blobs):
@@ -314,12 +333,17 @@ List of deprecated configuration parameters:
 - `output_fields` - A comma separated list of fields to include in output. Supported values are: `key`, `offset`, `timestamp` and `value`. Defaults to `value`.
 
 List of new configuration parameters:
-- `aws.access.key.id` - AWS Access Key ID for accessing S3 bucket. Mandatory.
-- `aws.secret.access.key` - AWS S3 Secret Access Key. Mandatory.
+- `aws.access.key.id` - AWS Access Key ID for accessing S3 bucket.
+- `aws.secret.access.key` - AWS S3 Secret Access Key.
 - `aws.s3.bucket.name` - - Name of an existing bucket for storing the records. Mandatory.
 - `aws.s3.endpoint` - The endpoint configuration (service endpoint & signing region) to be used for requests.
 - `aws.s3.prefix` - [Deprecated] Use `file.name.prefix` and `file.name.template` instead. The prefix that will be added to the file name in the bucket. Can be used for putting output files into a subdirectory.
 - `aws.s3.region` - Name of the region for the bucket used for storing the records. Defaults to `us-east-1`.
+- `aws.sts.role.arn` - AWS role ARN, for cross-account access role instead of `aws.access.key.id` and `aws.secret.access.key`
+- `aws.sts.role.external.id` - AWS ExternalId for cross-account access role
+- `aws.sts.role.session.name` - AWS session name for cross-account access role
+- `aws.sts.role.session.duration` - Session duration for cross-account access role in Seconds. Minimum value - 900. 
+- `aws.sts.config.endpoint` - AWS STS endpoint for cross-account access role.
 - `file.name.template` - The file name. The connector has the configurable template for file names. Constant string prefix could be added to the file name to put output files into a subdirectory.
 - `file.compression.type` - Compression type for output files. Supported algorithms are `gzip`, `snappy`, `zstd` and `none`. Defaults to `gzip`.
 - `format.output.fields` - A comma separated list of fields to include in output. Supported values are: `key`, `offset`, `timestamp` and `value`. Defaults to `value`.

--- a/build.gradle
+++ b/build.gradle
@@ -78,10 +78,11 @@ ext {
     // https://docs.confluent.io/current/installation/versions-interoperability.html
     confluentPlatformVersion = "4.1.4"
     amazonS3Version = "1.11.718"
+    amazonSTSVersion = "1.11.718"
     slf4jVersion = "1.7.25"
     aivenConnectCommonsVersion = "0.4.0"
     junitVersion = "5.6.2"
-    testcontainersVersion = "1.12.0"
+    testcontainersVersion = "1.15.1"
     localstackVersion = "0.2.5"
 }
 
@@ -117,6 +118,7 @@ dependencies {
 
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation "com.amazonaws:aws-java-sdk-s3:$amazonS3Version"
+    implementation "com.amazonaws:aws-java-sdk-sts:$amazonSTSVersion"
     implementation "io.aiven:aiven-kafka-connect-commons:$aivenConnectCommonsVersion"
     implementation "org.xerial.snappy:snappy-java:1.1.7.5"
     implementation "com.github.luben:zstd-jni:1.4.5-4"
@@ -133,6 +135,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
     testImplementation 'io.findify:s3mock_2.11:0.2.3'
     testImplementation "org.hamcrest:hamcrest:2.1"
+    testImplementation 'org.mockito:mockito-core:3.7.7'
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
     testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.3'

--- a/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkConnector.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkConnector.java
@@ -25,6 +25,8 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 
+import io.aiven.kafka.connect.s3.config.S3SinkConfig;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
@@ -42,9 +42,9 @@ import io.aiven.kafka.connect.common.output.jsonwriter.JsonLinesOutputWriter;
 import io.aiven.kafka.connect.common.output.jsonwriter.JsonOutputWriter;
 import io.aiven.kafka.connect.common.output.plainwriter.PlainOutputWriter;
 import io.aiven.kafka.connect.common.templating.VariableTemplatePart;
+import io.aiven.kafka.connect.s3.config.AwsCredentialProviderFactory;
+import io.aiven.kafka.connect.s3.config.S3SinkConfig;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.github.luben.zstd.ZstdOutputStream;
@@ -64,6 +64,8 @@ public class S3SinkTask extends SinkTask {
 
     private AmazonS3 s3Client;
 
+    protected AwsCredentialProviderFactory credentialFactory = new AwsCredentialProviderFactory();
+
     // required by Connect
     public S3SinkTask() {
 
@@ -79,12 +81,7 @@ public class S3SinkTask extends SinkTask {
             AmazonS3ClientBuilder
                 .standard()
                 .withCredentials(
-                    new AWSStaticCredentialsProvider(
-                        new BasicAWSCredentials(
-                            config.getAwsAccessKeyId().value(),
-                            config.getAwsSecretKey().value()
-                        )
-                    )
+                    credentialFactory.getProvider(config)
                 );
         if (Objects.isNull(awsEndpointConfig)) {
             s3ClientBuilder.withRegion(config.getAwsS3Region());

--- a/src/main/java/io/aiven/kafka/connect/s3/config/AwsAccessSecret.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/config/AwsAccessSecret.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3.config;
+
+import java.util.Objects;
+
+import org.apache.kafka.common.config.types.Password;
+
+final class AwsAccessSecret {
+    private final Password accessKeyId;
+    private final Password secretAccessKey;
+
+    public AwsAccessSecret(final Password accessKeyId, final Password secretAccessKey) {
+        this.accessKeyId = accessKeyId;
+        this.secretAccessKey = secretAccessKey;
+    }
+
+    public Password getAccessKeyId() {
+        return accessKeyId;
+    }
+
+    public Password getSecretAccessKey() {
+        return secretAccessKey;
+    }
+
+    public Boolean isValid() {
+        return Objects.nonNull(accessKeyId) && Objects.nonNull(secretAccessKey);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/s3/config/AwsCredentialProviderFactory.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/config/AwsCredentialProviderFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3.config;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+
+public class AwsCredentialProviderFactory {
+    public AWSCredentialsProvider getProvider(final S3SinkConfig config) {
+        if (config.hasAwsStsRole()) {
+            return getStsProvider(config);
+        }
+        return getBasicAwsCredentialsProvider(config);
+    }
+
+    private AWSCredentialsProvider getStsProvider(final S3SinkConfig config) {
+        final AwsStsRole awsstsRole = config.getStsRole();
+        final AWSSecurityTokenService sts = securityTokenService(config);
+        return new STSAssumeRoleSessionCredentialsProvider.Builder(awsstsRole.getArn(), awsstsRole.getSessionName())
+                .withStsClient(sts)
+                .withExternalId(awsstsRole.getExternalId())
+                .withRoleSessionDurationSeconds(awsstsRole.getSessionDurationSeconds())
+                .build();
+    }
+
+    private AWSSecurityTokenService securityTokenService(final S3SinkConfig config) {
+        if (config.hasStsEndpointConfig()) {
+            final AwsStsEndpointConfig endpointConfig = config.getStsEndpointConfig();
+            final AwsClientBuilder.EndpointConfiguration stsConfig =
+                    new AwsClientBuilder.EndpointConfiguration(endpointConfig.getServiceEndpoint(),
+                                                               endpointConfig.getSigningRegion());
+            final AWSSecurityTokenServiceClientBuilder stsBuilder =
+                    AWSSecurityTokenServiceClientBuilder.standard();
+            stsBuilder.setEndpointConfiguration(stsConfig);
+            return stsBuilder.build();
+        }
+        return AWSSecurityTokenServiceClientBuilder.defaultClient();
+    }
+
+    private AWSCredentialsProvider getBasicAwsCredentialsProvider(final S3SinkConfig config) {
+        final AwsAccessSecret awsCredentials = config.getAwsCredentials();
+        return new AWSStaticCredentialsProvider(
+                new BasicAWSCredentials(
+                        awsCredentials.getAccessKeyId().value(),
+                        awsCredentials.getSecretAccessKey().value()
+                )
+        );
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/s3/config/AwsStsEndpointConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/config/AwsStsEndpointConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3.config;
+
+import java.util.Objects;
+
+final class AwsStsEndpointConfig {
+    public static final String AWS_STS_GLOBAL_ENDPOINT = "https://sts.amazonaws.com";
+
+    private final String serviceEndpoint;
+    private final String signingRegion;
+
+    public AwsStsEndpointConfig(final String serviceEndpoint, final String signingRegion) {
+        this.serviceEndpoint = serviceEndpoint;
+        this.signingRegion = signingRegion;
+    }
+
+    public String getServiceEndpoint() {
+        return serviceEndpoint;
+    }
+
+    public String getSigningRegion() {
+        return signingRegion;
+    }
+
+    public Boolean isValid() {
+        return Objects.nonNull(signingRegion);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/s3/config/AwsStsRole.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/config/AwsStsRole.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3.config;
+
+import java.util.Objects;
+
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+
+final class AwsStsRole {
+
+    // AssumeRole request limit details here:
+    // https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
+    public static final int MIN_SESSION_DURATION = STSAssumeRoleSessionCredentialsProvider.DEFAULT_DURATION_SECONDS;
+    public static final int MAX_SESSION_DURATION = 43200;
+
+    private final String arn;
+    private final String externalId;
+    private final String sessionName;
+    private final int sessionDurationSeconds;
+
+    public AwsStsRole(final String arn,
+                      final String externalId,
+                      final String sessionName,
+                      final int sessionDurationSeconds) {
+        this.arn = arn;
+        this.externalId = externalId;
+        this.sessionName = sessionName;
+        this.sessionDurationSeconds = sessionDurationSeconds;
+    }
+
+    public String getArn() {
+        return arn;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getSessionName() {
+        return sessionName;
+    }
+
+    public int getSessionDurationSeconds() {
+        return sessionDurationSeconds;
+    }
+
+    public Boolean isValid() {
+        return Objects.nonNull(arn) && Objects.nonNull(sessionName);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfigDef.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfigDef.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.connect.s3;
+package io.aiven.kafka.connect.s3.config;
 
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/io/aiven/kafka/connect/s3/AwsCredentialProviderFactoryTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/AwsCredentialProviderFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3;
+
+import java.util.HashMap;
+
+import io.aiven.kafka.connect.s3.config.AwsCredentialProviderFactory;
+import io.aiven.kafka.connect.s3.config.S3SinkConfig;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.regions.Regions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+
+public class AwsCredentialProviderFactoryTest {
+
+    private AwsCredentialProviderFactory factory;
+    private HashMap<String, String> props;
+
+    @BeforeEach
+    public void setUp() {
+        factory = new AwsCredentialProviderFactory();
+        props = new HashMap<String, String>();
+        props.put(S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG, "anyBucket");
+    }
+
+    @Test
+    void createsStsCredentialProviderIfSpecified() {
+        props.put(S3SinkConfig.AWS_ACCESS_KEY_ID_CONFIG, "blah-blah-blah");
+        props.put(S3SinkConfig.AWS_SECRET_ACCESS_KEY_CONFIG, "blah-blah-blah");
+        props.put(S3SinkConfig.AWS_STS_ROLE_ARN, "arn:aws:iam::12345678910:role/S3SinkTask");
+        props.put(S3SinkConfig.AWS_STS_ROLE_SESSION_NAME, "SESSION_NAME");
+        props.put(S3SinkConfig.AWS_S3_REGION_CONFIG, Regions.US_EAST_1.getName());
+        props.put(S3SinkConfig.AWS_STS_CONFIG_ENDPOINT, "https://sts.us-east-1.amazonaws.com");
+
+        final var config = new S3SinkConfig(props);
+
+        final var credentialProvider = factory.getProvider(config);
+        assertThat(credentialProvider, instanceOf(STSAssumeRoleSessionCredentialsProvider.class));
+    }
+
+    @Test
+    void createStaticCredentialProviderByDefault() {
+        props.put(S3SinkConfig.AWS_ACCESS_KEY_ID_CONFIG, "blah-blah-blah");
+        props.put(S3SinkConfig.AWS_SECRET_ACCESS_KEY_CONFIG, "blah-blah-blah");
+
+        final var config = new S3SinkConfig(props);
+
+        final var credentialProvider = factory.getProvider(config);
+        assertThat(credentialProvider, instanceOf(AWSStaticCredentialsProvider.class));
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
@@ -32,7 +32,6 @@ import io.aiven.kafka.connect.common.config.OutputField;
 import io.aiven.kafka.connect.common.config.OutputFieldEncodingType;
 import io.aiven.kafka.connect.common.config.OutputFieldType;
 import io.aiven.kafka.connect.s3.OldFullKeyFormatters;
-import io.aiven.kafka.connect.s3.S3SinkConfig;
 
 import com.amazonaws.regions.Regions;
 import com.google.common.collect.Maps;
@@ -41,23 +40,23 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static io.aiven.kafka.connect.s3.S3SinkConfig.AWS_ACCESS_KEY_ID;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.AWS_ACCESS_KEY_ID_CONFIG;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.AWS_S3_BUCKET;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.AWS_S3_ENDPOINT;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.AWS_S3_PREFIX;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.AWS_S3_PREFIX_CONFIG;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.AWS_S3_REGION;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.AWS_S3_REGION_CONFIG;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.AWS_SECRET_ACCESS_KEY;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.AWS_SECRET_ACCESS_KEY_CONFIG;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.FILE_COMPRESSION_TYPE_CONFIG;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.FORMAT_OUTPUT_FIELDS_CONFIG;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.OUTPUT_COMPRESSION;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.OUTPUT_FIELDS;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.TIMESTAMP_SOURCE;
-import static io.aiven.kafka.connect.s3.S3SinkConfig.TIMESTAMP_TIMEZONE;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_ACCESS_KEY_ID;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_ACCESS_KEY_ID_CONFIG;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_S3_BUCKET;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_S3_ENDPOINT;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_S3_PREFIX;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_S3_PREFIX_CONFIG;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_S3_REGION;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_S3_REGION_CONFIG;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_SECRET_ACCESS_KEY;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_SECRET_ACCESS_KEY_CONFIG;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.FILE_COMPRESSION_TYPE_CONFIG;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.FORMAT_OUTPUT_FIELDS_CONFIG;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.OUTPUT_COMPRESSION;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.OUTPUT_FIELDS;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.TIMESTAMP_SOURCE;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.TIMESTAMP_TIMEZONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -85,9 +84,10 @@ class S3SinkConfigTest {
         props.put(S3SinkConfig.FORMAT_OUTPUT_FIELDS_VALUE_ENCODING_CONFIG, OutputFieldEncodingType.NONE.name);
 
         final var conf = new S3SinkConfig(props);
+        final var awsCredentials = conf.getAwsCredentials();
 
-        assertEquals("AWS_ACCESS_KEY_ID", conf.getAwsAccessKeyId().value());
-        assertEquals("AWS_SECRET_ACCESS_KEY", conf.getAwsSecretKey().value());
+        assertEquals("AWS_ACCESS_KEY_ID", awsCredentials.getAccessKeyId().value());
+        assertEquals("AWS_SECRET_ACCESS_KEY", awsCredentials.getSecretAccessKey().value());
         assertEquals("THE_BUCKET", conf.getAwsS3BucketName());
         assertEquals("AWS_S3_PREFIX", conf.getAwsS3Prefix());
         assertEquals("AWS_S3_ENDPOINT", conf.getAwsS3EndPoint());
@@ -128,9 +128,10 @@ class S3SinkConfigTest {
         );
 
         final var conf = new S3SinkConfig(props);
+        final var awsCredentials = conf.getAwsCredentials();
 
-        assertEquals("AWS_ACCESS_KEY_ID", conf.getAwsAccessKeyId().value());
-        assertEquals("AWS_SECRET_ACCESS_KEY", conf.getAwsSecretKey().value());
+        assertEquals("AWS_ACCESS_KEY_ID", awsCredentials.getAccessKeyId().value());
+        assertEquals("AWS_SECRET_ACCESS_KEY", awsCredentials.getSecretAccessKey().value());
         assertEquals("THE_BUCKET", conf.getAwsS3BucketName());
         assertEquals("AWS_S3_PREFIX", conf.getAwsS3Prefix());
         assertEquals("AWS_S3_ENDPOINT", conf.getAwsS3EndPoint());
@@ -181,9 +182,10 @@ class S3SinkConfigTest {
         props.put(OUTPUT_FIELDS, "key, value");
 
         final var conf = new S3SinkConfig(props);
+        final var awsCredentials = conf.getAwsCredentials();
 
-        assertEquals("AWS_ACCESS_KEY_ID", conf.getAwsAccessKeyId().value());
-        assertEquals("AWS_SECRET_ACCESS_KEY", conf.getAwsSecretKey().value());
+        assertEquals("AWS_ACCESS_KEY_ID", awsCredentials.getAccessKeyId().value());
+        assertEquals("AWS_SECRET_ACCESS_KEY", awsCredentials.getSecretAccessKey().value());
         assertEquals("THE_BUCKET", conf.getAwsS3BucketName());
         assertEquals("AWS_S3_PREFIX", conf.getAwsS3Prefix());
         assertEquals("AWS_S3_ENDPOINT", conf.getAwsS3EndPoint());
@@ -689,5 +691,132 @@ class S3SinkConfigTest {
                 + "for configuration file.name.template: unsupported set of template variables parameters, "
                 + "supported sets are: start_offset:padding=true|false,timestamp:unit=yyyy|MM|dd|HH",
             t.getMessage());
+    }
+
+    @Test
+    void stsRoleCorrectConfig() {
+        final var props = new HashMap<String, String>();
+
+        props.put(S3SinkConfig.AWS_STS_ROLE_ARN, "arn:aws:iam::12345678910:role/S3SinkTask");
+        props.put(S3SinkConfig.AWS_STS_ROLE_EXTERNAL_ID, "EXTERNAL_ID");
+        props.put(S3SinkConfig.AWS_STS_ROLE_SESSION_NAME, "SESSION_NAME");
+        props.put(S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG, "THE_BUCKET");
+        props.put(S3SinkConfig.AWS_S3_REGION_CONFIG, Regions.US_EAST_1.getName());
+
+        final var conf = new S3SinkConfig(props);
+
+        assertEquals("arn:aws:iam::12345678910:role/S3SinkTask", conf.getStsRole().getArn());
+        assertEquals("EXTERNAL_ID", conf.getStsRole().getExternalId());
+        assertEquals("SESSION_NAME", conf.getStsRole().getSessionName());
+        assertEquals(Regions.US_EAST_1, conf.getAwsS3Region());
+    }
+
+    @Test
+    void stsRoleEmptyArn() {
+        final var props = new HashMap<String, String>();
+
+        props.put(S3SinkConfig.AWS_STS_ROLE_EXTERNAL_ID, "EXTERNAL_ID");
+        props.put(S3SinkConfig.AWS_STS_ROLE_SESSION_NAME, "SESSION_NAME");
+        props.put(S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG, "THE_BUCKET");
+        props.put(S3SinkConfig.AWS_S3_REGION_CONFIG, Regions.US_EAST_1.getName());
+
+        final Throwable t = assertThrows(
+            ConfigException.class,
+            () -> new S3SinkConfig(props)
+        );
+        assertEquals(
+                "Either {aws.access.key.id, aws.secret.access.key} or"
+                        + " {aws.sts.role.arn, aws.sts.role.session.name} should be set",
+                t.getMessage()
+        );
+    }
+
+    @Test
+    void stsRoleEmptySessionName() {
+        final var props = new HashMap<String, String>();
+
+        props.put(S3SinkConfig.AWS_STS_ROLE_ARN, "arn:aws:iam::12345678910:role/S3SinkTask");
+        props.put(S3SinkConfig.AWS_STS_ROLE_EXTERNAL_ID, "EXTERNAL_ID");
+        props.put(S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG, "THE_BUCKET");
+        props.put(S3SinkConfig.AWS_S3_REGION_CONFIG, Regions.US_EAST_1.getName());
+
+        final Throwable t = assertThrows(
+            ConfigException.class,
+            () -> new S3SinkConfig(props)
+        );
+        assertEquals(
+                "Either {aws.access.key.id, aws.secret.access.key} or"
+                        + " {aws.sts.role.arn, aws.sts.role.session.name} should be set",
+                t.getMessage()
+        );
+    }
+
+    @Test
+    void stsWrongSessionDuration() {
+        final var props = new HashMap<String, String>();
+
+        props.put(S3SinkConfig.AWS_STS_ROLE_ARN, "arn:aws:iam::12345678910:role/S3SinkTask");
+        props.put(S3SinkConfig.AWS_STS_ROLE_SESSION_NAME, "SESSION_NAME");
+        props.put(S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG, "THE_BUCKET");
+        props.put(S3SinkConfig.AWS_S3_REGION_CONFIG, Regions.US_EAST_1.getName());
+
+        props.put(S3SinkConfig.AWS_STS_ROLE_SESSION_DURATION, "30");
+
+        final Throwable t = assertThrows(
+            ConfigException.class,
+            () -> new S3SinkConfig(props)
+        );
+        assertEquals(
+                "Invalid value 30 for configuration aws.sts.role.session.duration: Value must be at least 900",
+                t.getMessage()
+        );
+
+        props.put(S3SinkConfig.AWS_STS_ROLE_SESSION_DURATION, "50000");
+
+        final Throwable t2 = assertThrows(
+            ConfigException.class,
+            () -> new S3SinkConfig(props)
+        );
+        assertEquals(
+            "Invalid value 50000 for configuration aws.sts.role.session.duration: Value must be no more than 43200",
+            t2.getMessage()
+        );
+    }
+
+    @Test
+    void stsCorrectSessionDuration() {
+        final var props = new HashMap<String, String>();
+
+        props.put(S3SinkConfig.AWS_STS_ROLE_ARN, "arn:aws:iam::12345678910:role/S3SinkTask");
+        props.put(S3SinkConfig.AWS_STS_ROLE_SESSION_NAME, "SESSION_NAME");
+        props.put(S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG, "THE_BUCKET");
+        props.put(S3SinkConfig.AWS_S3_REGION_CONFIG, Regions.US_EAST_1.getName());
+
+        props.put(S3SinkConfig.AWS_STS_ROLE_SESSION_DURATION, "900");
+
+        final var conf = new S3SinkConfig(props);
+
+        assertEquals(900, conf.getStsRole().getSessionDurationSeconds());
+    }
+
+    @Test
+    void stsEndpointShouldNotBeSetWithoutRegion() {
+        final var props = new HashMap<String, String>();
+
+        props.put(S3SinkConfig.AWS_STS_ROLE_ARN, "arn:aws:iam::12345678910:role/S3SinkTask");
+        props.put(S3SinkConfig.AWS_STS_ROLE_EXTERNAL_ID, "EXTERNAL_ID");
+        props.put(S3SinkConfig.AWS_STS_ROLE_SESSION_NAME, "SESSION_NAME");
+        props.put(S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG, "THE_BUCKET");
+        props.put(S3SinkConfig.AWS_STS_CONFIG_ENDPOINT, "https://sts.eu-north-1.amazonaws.com");
+
+        final Throwable t3 = assertThrows(
+            ConfigException.class,
+            () -> new S3SinkConfig(props)
+        );
+        assertEquals(
+            "aws.s3.region should be specified together with aws.sts.config.endpoint",
+            t3.getMessage()
+        );
+
     }
 }


### PR DESCRIPTION
This is PR that should make possible to use cross account roles. AWSAccessKey and AWSSecretAccessKey will not be mandatory anymore.

Missing:
- [ ] IntegrationTests*

* Feature was manually tested. Integration testing is tricky because of necessity to use multiple "accounts". Lets not block release and make a separate PR for integration tests