### PR TITLE
Rename connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aiven Kafka S3 Connector
+# Kafka S3 Connector
 
 ![Pull Request Workflow](https://github.com/aiven/aiven-kafka-connect-s3/workflows/Pull%20Request%20Workflow/badge.svg)
 


### PR DESCRIPTION
It's incorrect to say `Aiven Kafka S3 Connector` for the trademark reason.